### PR TITLE
Scope Product Detail Tabs CSS

### DIFF
--- a/Themes/ClassicRazor/css/classicrazor.css
+++ b/Themes/ClassicRazor/css/classicrazor.css
@@ -185,14 +185,14 @@ input.quantity {float:left;margin:0 6px;}
 .buybuttonhide {display:none;}
 
 /* Details Tabs */
-.nav-tabs {margin:0;padding:0;float:left;}
-.nav-tabs li {display:block;float:left;font-weight:normal;margin-right:1px;}
-.nav-tabs li a {display:block;background:#505050;color:white;text-decoration:none;padding:10px 20px;}
-.nav-tabs li a:hover {background:#757370;}
-.tab-content {clear:both;padding:20px 0;display:none;}
-.tab-content h3 {margin-bottom:20px;}
-.tab-content.tab-active {display:block;}
-.tab-content.tab-hide {display:none;}
+.productdetail .nav-tabs {margin:0;padding:0;float:left;}
+.productdetail .nav-tabs li {display:block;float:left;font-weight:normal;margin-right:1px;}
+.productdetail .nav-tabs li a {display:block;background:#505050;color:white;text-decoration:none;padding:10px 20px;}
+.productdetail .nav-tabs li a:hover {background:#757370;}
+.productdetail .tab-content {clear:both;padding:20px 0;display:none;}
+.productdetail .tab-content h3 {margin-bottom:20px;}
+.productdetail .tab-content.tab-active {display:block;}
+.productdetail .tab-content.tab-hide {display:none;}
 .sharingwidget {float:left;background:#505050;color:white;padding:0 20px;}
 .sharingwidget .share {padding:10px 3px 10px 0;float:left;}
 .addthis_sharing_toolbox {margin-top:12px;line-height:normal;}


### PR DESCRIPTION
I bumped into these styles over riding other bootstrap tabs and causing issues.  Specifically the .tab-content {clear:both;padding:20px 0;display:none;}.  I think this styling might be better confined to the productdetail class??
