### PR TITLE
Add Empty Basket Text Resx

### DIFF
--- a/App_LocalResources/General.ascx.resx
+++ b/App_LocalResources/General.ascx.resx
@@ -1023,6 +1023,9 @@
   <data name="basket.Text" xml:space="preserve">
     <value>Basket</value>
   </data>
+  <data name="txtemptybasket.Text" xml:space="preserve">
+    <value>Basket (0)</value>
+  </data>
   <data name="favorites.Text" xml:space="preserve">
     <value>Favorites</value>
   </data>


### PR DESCRIPTION
This key is used in the mini cart.  I'm not sure I chose the best default value but I think the key value pair should be in the resx.

https://github.com/nbrightproject/NBrightBuy/issues/34
