### PR TITLE
Delete USERPRDXREF

### DIFF
--- a/Admin/Tools.ascx.cs
+++ b/Admin/Tools.ascx.cs
@@ -170,6 +170,8 @@ namespace Nevoweb.DNN.NBrightBuy.Admin
                     objCtrl.ExecSql(stmt);
                     stmt = "delete from " + dbOwner + "[" + objQual + "NBrightBuy] where PortalId = " + PortalId.ToString("") + " and typecode = 'PRDXREF' ";
                     objCtrl.ExecSql(stmt);
+                    stmt = "delete from " + dbOwner + "[" + objQual + "NBrightBuy] where PortalId = " + PortalId.ToString("") + " and typecode = 'USERPRDXREF' ";
+                    objCtrl.ExecSql(stmt);
                     stmt = "delete from " + dbOwner + "[" + objQual + "NBrightBuy] where PortalId = " + PortalId.ToString("") + " and typecode = 'CATCASCADE' ";
                     objCtrl.ExecSql(stmt);
                     stmt = "delete from " + dbOwner + "[" + objQual + "NBrightBuy] where PortalId = " + PortalId.ToString("") + " and typecode = 'CATXREF' ";


### PR DESCRIPTION
It would make sense to get rid of these records during the product delete operation.  There would be nothing for them to link to once the products are gone.
