### PR TITLE
Allow png files

### DIFF
--- a/Themes/config/default/settingsbody.html
+++ b/Themes/config/default/settingsbody.html
@@ -333,7 +333,7 @@
                     </div>
                     <div class="form-group">
                         <label class="col-sm-3 control-label">[<tag type="valueof" resourcekey="Settings.fileregexpr" />]</label>
-                        <div class="col-sm-5">[<tag id="fileregexpr" cssclass="form-control" type="textbox" width="300" maxlength="250" Text="^.*\.(txt|gif|jpe?g|jpg|pdf|doc|docx|xls|xlsx|zip)" />]</div>
+                        <div class="col-sm-5">[<tag id="fileregexpr" cssclass="form-control" type="textbox" width="300" maxlength="250" Text="^.*\.(txt|gif|jpe?g|jpg|png|pdf|doc|docx|xls|xlsx|zip)" />]</div>
                     </div>
 
 	            </div>


### PR DESCRIPTION
Currently if you try to add a png image to a product it will fail with no error message.  This would help avoid a little confusion until the UI validates and alerts the end user.  