### PR TITLE
Fixed issue where TabId of NBrightBuyBase was -1

### DIFF
--- a/Base/NBrightBuyBase.cs
+++ b/Base/NBrightBuyBase.cs
@@ -86,7 +86,13 @@ namespace Nevoweb.DNN.NBrightBuy.Base
             }
         }
 
-
+        protected new int TabId
+        {
+            get
+            {
+                return PortalSettings.Current.ActiveTab.TabID;
+            }
+        }
 
 
         #region "Display Methods"


### PR DESCRIPTION
TabId of NBrightBuyBase was -1 because the subclass (PortalModuleBase) isn't able to set it correctly due to the fact that the module is initialised via the Skin (not via a Page).

Creating an overload to the ActiveTab.TabId fixed it.

This fix was needed to improve collaboration with Satrabel OpenUrlRewriter.