### PR TITLE
Prevent model label line breaks in Editor

### DIFF
--- a/Themes/config/css/backoffice.css
+++ b/Themes/config/css/backoffice.css
@@ -194,6 +194,7 @@ a.sortelementUp,a.sortelementDown{cursor:pointer;position:absolute;display:block
 .selectrelated .selectlistitem .selectproduct .fa{color: #DDDDDD;}
 .selectrelated .selectlistitem .selectproduct .fa:hover{color: #51A3C4;}
 #productlist .NBrightPagingDiv{}
+#productmodels li.modelitem label {white-space:nowrap;}
 
 /* Category and Property Lists */
 .categorylist td{vertical-align: middle !important;}


### PR DESCRIPTION
Css fix to prevent the Product Editor Models section Dealer Sale label from line breaks.  It may render for extra large screens but on a large portion of screens the Dealer Sale label causes a minor line break.