### PR TITLE
Change masonry init to use related item width

### DIFF
--- a/Themes/ClassicRazor/Default/NBS_ProductDisplayDetail.cshtml
+++ b/Themes/ClassicRazor/Default/NBS_ProductDisplayDetail.cshtml
@@ -345,7 +345,7 @@
                     var rproduct = new ProductData(rp.ItemID, rp.Lang);
                     <div class="product" style="width: @Model.GetSetting("relateditemwidth")px; height: @Model.GetSetting("relateditemheight"); margin-bottom: @Model.GetSetting("relateditembottommargin")px">
 
-                        <div class="productimg" style="width: 294px; height: @(Model.GetSetting("relateditemimagecontainerheight"))">
+                        <div class="productimg" style="height: @(Model.GetSetting("relateditemimagecontainerheight"))">
 
                             @if (rp.GetXmlProperty("genxml/imgs/genxml[1]/hidden/imageurl") != "")
                             {

--- a/Themes/ClassicRazor/Default/NBS_ProductDisplayDetail_head.cshtml
+++ b/Themes/ClassicRazor/Default/NBS_ProductDisplayDetail_head.cshtml
@@ -230,7 +230,7 @@
     $(document).ready(function() {
 
         var $container = $('.productlist').masonry({
-            columnWidth: @Model.GetSetting("classicitemwidth"), // List item width - Can also use CSS width of first list item
+            columnWidth: @Model.GetSetting("relateditemwidth"), // List item width - Can also use CSS width of first list item
             itemSelector: '.product',
             gutter: @Model.GetSetting("classicitemgutter"), // Set horizontal gap and include in calculations. Also used in CSS for vertical gap
             isOriginLeft: true, // Build from right to left if false

--- a/Themes/ClassicRazor/Default/NBS_ProductDisplayDetail_head.cshtml
+++ b/Themes/ClassicRazor/Default/NBS_ProductDisplayDetail_head.cshtml
@@ -232,7 +232,7 @@
         var $container = $('.productlist').masonry({
             columnWidth: @Model.GetSetting("relateditemwidth"), // List item width - Can also use CSS width of first list item
             itemSelector: '.product',
-            gutter: @Model.GetSetting("classicitemgutter"), // Set horizontal gap and include in calculations. Also used in CSS for vertical gap
+            gutter: @Model.GetSetting("classicrelateditemgutter"), // Set horizontal gap and include in calculations. Also used in CSS for vertical gap
             isOriginLeft: true, // Build from right to left if false
             isOriginTop: true // Build from bottom to top if false
         });


### PR DESCRIPTION
I think the masonry grid on the detail page should be using the related item width settings rather than the item width.