### PR TITLE
Prevent ClientEditors from viewing all orders

### DIFF
--- a/XmlConnector.ashx.cs
+++ b/XmlConnector.ashx.cs
@@ -2725,12 +2725,12 @@ namespace Nevoweb.DNN.NBrightBuy
                 filter += " and ([xmldata].value('(genxml/dropdownlist/orderstatus)[1]', 'nvarchar(max)') = '" + searchorderstatus + "')   ";
             }
 
-            // check for user or manager.
-            if (!NBrightBuyUtils.CheckRights())
+            // check for admins, editors or managers (not clienteditors).  
+            if (!NBrightBuyUtils.CheckRights() || UserController.Instance.GetCurrentUserInfo().IsInRole(StoreSettings.ClientEditorRole))
             {
-                    filter += " and ( userid = " + UserController.Instance.GetCurrentUserInfo().UserID + ")   ";
+                filter += " and ( userid = " + UserController.Instance.GetCurrentUserInfo().UserID + ")   ";
             }
-            
+
             var recordCount = 0;
 
             if (themeFolder == "")


### PR DESCRIPTION
Restrict ClientEditors to only be able to view their orders.  I don't believe this role should be able to see every order in the system.