### PR TITLE
Mods to match address labels with DNN Profile properties. 

### DIFF
--- a/App_LocalResources/General.ascx.resx
+++ b/App_LocalResources/General.ascx.resx
@@ -421,10 +421,10 @@
     <value>Last Name</value>
   </data>
   <data name="lblAddress1.Text" xml:space="preserve">
-    <value>Address line 1</value>
+    <value>Unit</value>
   </data>
   <data name="lblAddress2.Text" xml:space="preserve">
-    <value>Address line 2</value>
+    <value>Address</value>
   </data>
   <data name="lblTown.Text" xml:space="preserve">
     <value>Town</value>


### PR DESCRIPTION
Currently Address1 updates the Unit Profile Property.  Similarly, Address 2 updates the Address Profile Property.  Mods to string resources should help clarify the actual DNN profile properties being updated.